### PR TITLE
Test changes and clean up

### DIFF
--- a/openbis_upload_helper/app/utils/utils.py
+++ b/openbis_upload_helper/app/utils/utils.py
@@ -20,7 +20,6 @@ from pybis import Openbis
 from openbis_upload_helper.uploader.entry_points import get_entry_point_parsers
 
 
-
 def get_cipher_suite():
     """Return a Fernet instance using the configured secret key.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,7 @@ dev = [
     "structlog==24.4.0",
     "watchfiles==1.1.1",
     "werkzeug[watchdog]==3.1.4",
+    "ruff",
 ]
 parsers = [
     "masterdata-parser-example@git+https://github.com/BAMresearch/masterdata-parser-example.git@main",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,78 @@
+[build-system]
+requires = ["setuptools>=61.0.0", "setuptools-scm>=8.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "openbis_upload_helper"
+version = "0.1.0"
+description = "The openBIS Upload Helper is a tool to parse files and extract their relevant metadata into objects and vocabularies in openBIS."
+readme = "README.md"
+
+license = { text = "Not open source" }
+authors = [
+  { name = "Jose M. Pizarro", email = "jose.pizarro-blanco@bam.de" },
+]
+requires-python = ">=3.12.12"
+dependencies = [
+    "argon2-cffi==25.1.0",
+    "celery==5.6.0",
+    "crispy-bootstrap5==2025.6",
+    "django==5.2.9",
+    "django-allauth[mfa]==65.13.1",
+    "django-anymail[mailgun]==14.0",
+    "django-celery-beat==2.8.1",
+    "django-crispy-forms==2.5",
+    "django-environ==0.12.0",
+    "django-model-utils==5.0.0",
+    "django-redis==6.0.0",
+    "gunicorn==23.0.0",
+    "hiredis==3.3.0",
+    "pillow==12.0.0",
+    "psycopg[binary]==3.3.2",
+    "python-slugify==8.0.4",
+    "redis==7.1.0",
+    "sentry-sdk==2.48.0",
+    "uvicorn-worker==0.4.0",
+    "uvicorn[standard]==0.38.0",
+    "whitenoise==6.11.0",
+    "bam-masterdata>=0.8.4",
+]
+
+[project.urls]
+"Homepage" = "https://github.com/BAMresearch/openbis-upload-helper"
+"Bug Tracker" = "https://github.com/BAMresearch/openbis-upload-helper/issues"
+
+[project.optional-dependencies]
+dev = [
+    "coverage==7.13.0",
+    "django-coverage-plugin==3.2.0",
+    "django-debug-toolbar==6.1.0",
+    "django-extensions==4.1",
+    "django-stubs[compatible-mypy]==5.2.8",
+    "djlint==1.36.4",
+    "factory-boy==3.3.2",
+    "ipdb==0.13.13",
+    "mypy==1.19.1",
+    "pre-commit==4.5.1",
+    "psycopg[binary]==3.3.2",
+    "pytest==9.0.2",
+    "pytest-cov",
+    "pytest-django==4.11.1",
+    "pytest-sugar==1.1.1",
+    "pytest-timeout",
+    "ruff==0.14.10",
+    "sphinx==9.0.4",
+    "sphinx-autobuild==2025.8.25",
+    "structlog==24.4.0",
+    "watchfiles==1.1.1",
+    "werkzeug[watchdog]==3.1.4",
+]
+parsers = [
+    "masterdata-parser-example@git+https://github.com/BAMresearch/masterdata-parser-example.git@main",
+]
+
+# "sigmabam2openbis@git+https://github.com/BAMresearch/sigmabam2openbis.git@main"
+
 # ==== pytest ====
 [tool.pytest.ini_options]
 minversion = "6.0"
@@ -6,8 +81,6 @@ python_files = [
     "tests.py",
     "test_*.py",
 ]
-DJANGO_SETTINGS_MODULE = "config.settings.test"
-
 
 # ==== Coverage ====
 [tool.coverage.run]
@@ -91,68 +164,27 @@ indent-width = 4
 
 [tool.ruff.lint]
 select = [
-    "F",
-    "E",
-    "W",
-    "C90",
-    "I",
-    "N",
-    "UP",
-    "YTT",
-    # "ANN", # flake8-annotations: we should support this in the future but 100+ errors atm
-    "ASYNC",
-    "S",
-    "BLE",
-    "FBT",
-    "B",
-    "A",
-    "COM",
-    "C4",
-    "DTZ",
-    "T10",
-    "DJ",
-    "EM",
-    "EXE",
-    "FA",
-    'ISC',
-    "ICN",
-    "G",
-    'INP',
-    'PIE',
-    "T20",
-    'PYI',
-    'PT',
-    "Q",
-    "RSE",
-    "RET",
-    "SLF",
-    "SLOT",
-    "SIM",
-    "TID",
-    "TC",
-    "INT",
-    # "ARG", # Unused function argument
-    "PTH",
-    "ERA",
-    "PD",
-    "PGH",
-    "PL",
-    "TRY",
-    "FLY",
-    # "NPY",
-    # "AIR",
-    "PERF",
-    # "FURB",
-    # "LOG",
-    "RUF",
+    "E", # pycodestyle
+    "PL", # pylint
+    "F", # Pyflakes
+    "UP", # pyupgrade
+    "I", # isort
 ]
 ignore = [
-    "S101", # Use of assert detected https://docs.astral.sh/ruff/rules/assert/
-    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
-    "SIM102", # sometimes it's better to nest
-    # of types for comparison.
-    # Deactivated because it can make the code slow:
-    # https://github.com/astral-sh/ruff/issues/7871
+    "F401", # Module imported but unused
+    "E501", # Line too long ({width} > {limit} characters)
+    "E701", # Multiple statements on one line (colon)
+    "E731", # Do not assign a lambda expression, use a def
+    "E402",  # Module level import not at top of file
+    "PLR0911", # Too many return statements
+    "PLR0912", # Too many branches
+    "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR2004", # Magic value used instead of constant
+    "PLW0603", # Using the global statement
+    "PLW2901", # redefined-loop-name
+    "PLR1714", # consider-using-in
+    "PLR5501", # else-if-used
 ]
 fixable = ["ALL"]
 # Allow unused variables when underscore-prefixed.
@@ -161,89 +193,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 [tool.ruff.lint.isort]
 force-single-line = true
 
-[dependency-groups]
-dev = [
-    "coverage==7.13.0",
-    "django-coverage-plugin==3.2.0",
-    "django-debug-toolbar==6.1.0",
-    "django-extensions==4.1",
-    "django-stubs[compatible-mypy]==5.2.8",
-    "djlint==1.36.4",
-    "factory-boy==3.3.2",
-    "ipdb==0.13.13",
-    "mypy==1.19.1",
-    "pre-commit==4.5.1",
-    "psycopg[binary]==3.3.2",
-    "pytest==9.0.2",
-    "pytest-django==4.11.1",
-    "pytest-sugar==1.1.1",
-    "ruff==0.14.10",
-    "sphinx==9.0.4",
-    "sphinx-autobuild==2025.8.25",
-    "watchfiles==1.1.1",
-    "werkzeug[watchdog]==3.1.4",
-]
-
-[project]
-name = "openbis_upload_helper"
-version = "0.1.0"
-description = "The openBIS Upload Helper is a tool to parse files and extract their relevant metadata into objects and vocabularies in openBIS."
-readme = "README.md"
-
-license = { text = "Not open source" }
-authors = [
-  { name = "Jose M. Pizarro", email = "jose.pizarro-blanco@bam.de" },
-]
-requires-python = ">=3.12.12"
-dependencies = [
-    "argon2-cffi==25.1.0",
-    "celery==5.6.0",
-    "crispy-bootstrap5==2025.6",
-    "django==5.2.9",
-    "django-allauth[mfa]==65.13.1",
-    "django-anymail[mailgun]==14.0",
-    "django-celery-beat==2.8.1",
-    "django-crispy-forms==2.5",
-    "django-environ==0.12.0",
-    "django-model-utils==5.0.0",
-    "django-redis==6.0.0",
-    "gunicorn==23.0.0",
-    "hiredis==3.3.0",
-    "pillow==12.0.0",
-    "psycopg[binary]==3.3.2",
-    "python-slugify==8.0.4",
-    "redis==7.1.0",
-    "sentry-sdk==2.48.0",
-    "uvicorn-worker==0.4.0",
-    "uvicorn[standard]==0.38.0",
-    "whitenoise==6.11.0",
-    "bam-masterdata>=0.8.4",
-]
-
-[build-system]
-requires = ["setuptools>=61.0.0", "setuptools-scm>=8.0"]
-build-backend = "setuptools.build_meta"
-
-[project.urls]
-"Homepage" = "https://github.com/BAMresearch/openbis-upload-helper"
-"Bug Tracker" = "https://github.com/BAMresearch/openbis-upload-helper/issues"
-
-[project.optional-dependencies]
-dev = [
-    "mypy==1.18.1",
-    "django-stubs",
-    "pytest",
-    "pytest-timeout",
-    "pytest-cov",
-    "structlog==24.4.0",
-]
-parsers = [
-    "masterdata-parser-example@git+https://github.com/BAMresearch/masterdata-parser-example.git@main",
-]
-
-# "sigmabam2openbis@git+https://github.com/BAMresearch/sigmabam2openbis.git@main"
-
-
+# this is entirely optional, you can remove this if you wish to
 [tool.ruff.format]
 # use double quotes for strings.
 quote-style = "double"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,12 @@ def configure_django_settings():
     if not settings.configured:
         django.setup()
     settings.ROOT_URLCONF = "openbis_upload_helper.app.urls"
+    settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
+    # pytest-django clears django.core.mail.outbox automatically; ensure it exists
+    from django.core import mail  # noqa: PLC0415
+
+    if not hasattr(mail, "outbox"):
+        mail.outbox = []
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import base64
 import os
 from unittest.mock import MagicMock
 
+import django
 import pytest
 from bam_masterdata.logger import log_storage
 from bam_masterdata.metadata.definitions import ObjectTypeDef
@@ -25,6 +26,14 @@ if os.getenv("_PYTEST_RAISE", "0") != "0":
     @pytest.hookimpl(tryfirst=True)
     def pytest_internalerror(excinfo):
         raise excinfo.value
+
+
+@pytest.fixture(scope="session", autouse=True)
+def configure_django_settings():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.test")
+    if not settings.configured:
+        django.setup()
+    settings.ROOT_URLCONF = "openbis_upload_helper.app.urls"
 
 
 @pytest.fixture(autouse=True)
@@ -335,3 +344,34 @@ def set_secret_encryption_key():
     settings.SECRET_ENCRYPTION_KEY = base64.urlsafe_b64encode(
         Fernet.generate_key(),
     ).decode()
+
+
+class DummySession(dict):
+    def __init__(self):
+        super().__init__()
+        self.flushed = False
+
+    def flush(self):
+        self.flushed = True
+        self.clear()
+
+
+@pytest.fixture
+def attach_session():
+    def _attach(request):
+        request.session = DummySession()
+        return request
+
+    return _attach
+
+
+@pytest.fixture
+def make_uploaded_file():
+    def _make(name="file.txt", content=b"x"):
+        uploaded_file = MagicMock()
+        uploaded_file.name = name
+        uploaded_file.size = len(content)
+        uploaded_file.chunks.return_value = [content]
+        return uploaded_file
+
+    return _make

--- a/tests/entry_points/test_load.py
+++ b/tests/entry_points/test_load.py
@@ -1,7 +1,21 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
 from openbis_upload_helper.uploader.entry_points import get_entry_point_parsers
 
 
-def test_get_entry_point_parsers():
+@patch("importlib.metadata.entry_points")
+def test_get_entry_point_parsers(mock_entry_points):
+    mock_entry_points.return_value = [
+        SimpleNamespace(
+            name="masterdata_parser_example_entry_point",
+            load=lambda: {
+                "name": "MasterdataParserExample",
+                "description": "An example parser for masterdata.",
+                "parser_class": object(),
+            },
+        ),
+    ]
     parsers = get_entry_point_parsers()
     assert isinstance(parsers, dict)
     assert "masterdata_parser_example_entry_point" in parsers

--- a/tests/test_dummy.py
+++ b/tests/test_dummy.py
@@ -1,2 +1,0 @@
-def test_dummy():
-    assert True

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,104 +1,392 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from django.http import HttpResponse
+from django.http import HttpResponseRedirect
 from django.test import RequestFactory
+from django.test import override_settings
+from django.test.client import MULTIPART_CONTENT
+from django.urls import reverse
 
-from openbis_upload_helper.app.views import login
+from openbis_upload_helper.app import views
 
 factory = RequestFactory()
 
 
-@patch("openbis_upload_helper.app.views.render")
+@override_settings(OPENBIS_URL="https://openbis.example")
+@patch("openbis_upload_helper.app.views.cache")
+@patch("openbis_upload_helper.app.views.encrypt_password")
 @patch("openbis_upload_helper.app.views.Openbis")
-def test_login_view_success(mock_openbis_class, mock_render, mock_openbis):
-    mock_render.return_value = None
-
+def test_login_view_success(
+    mock_openbis_class,
+    mock_encrypt,
+    mock_cache,
+    mock_openbis,
+    attach_session,
+):
     mock_openbis_class.return_value = mock_openbis
+    mock_encrypt.return_value = "encrypted"
 
-    # Simulate a POST request with username and password
-    request = factory.post(
-        "/login",
-        {"username": "testuser", "password": "correct_password"},
+    request = attach_session(
+        factory.post(
+            "/login",
+            {"username": "testuser", "password": "correct_password"},
+        ),
     )
-    _ = login(request)
+    response = views.login(request)
 
-    mock_openbis_class.assert_called_once()
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    mock_openbis_class.assert_called_once_with("https://openbis.example")
     mock_openbis.login.assert_called_once_with(
         "testuser",
         "correct_password",
         save_token=True,
     )
+    assert request.session["openbis_username"] == "testuser"
+    assert request.session["openbis_password"] == "encrypted"
+    assert "openbis_session_id" in request.session
     assert mock_openbis.logged_in is True
+    mock_cache.set.assert_called_once()
 
 
-@patch("openbis_upload_helper.app.views.render")
+@override_settings(OPENBIS_URL="https://openbis.example")
+@patch("openbis_upload_helper.app.views.cache")
+@patch("openbis_upload_helper.app.views.encrypt_password")
 @patch("openbis_upload_helper.app.views.Openbis")
-def test_login_view_token(mock_openbis_class, mock_render, mock_openbis):
-    mock_render.return_value = None
-
+def test_login_view_token(
+    mock_openbis_class,
+    mock_encrypt,
+    mock_cache,
+    mock_openbis,
+    attach_session,
+):
     mock_openbis_class.return_value = mock_openbis
+    mock_encrypt.return_value = "encrypted"
 
-    # simulate a POST request with a personal access token
-    request = factory.post("/login", {"personal_access_token": "mytoken"})
-    _ = login(request)
+    request = attach_session(
+        factory.post("/login", {"personal_access_token": "mytoken"}),
+    )
+    response = views.login(request)
 
-    mock_openbis_class.assert_called_once()
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    mock_openbis_class.assert_called_once_with("https://openbis.example")
     mock_openbis.set_token.assert_called_once_with(
         "mytoken",
         save_token=True,
     )
+    assert request.session["openbis_username"] == ""
+    assert request.session["openbis_password"] == "encrypted"
+    assert "openbis_session_id" in request.session
     assert mock_openbis.logged_in is True
+    mock_cache.set.assert_called_once()
 
 
+@override_settings(OPENBIS_URL="https://openbis.example")
 @patch("openbis_upload_helper.app.views.render")
 @patch("openbis_upload_helper.app.views.Openbis")
-def test_login_view_failure(mock_openbis_class, mock_render, mock_openbis):
-    mock_render.return_value = None
-
+def test_login_view_failure(
+    mock_openbis_class, mock_render, mock_openbis, attach_session
+):
     mock_openbis_class.return_value = mock_openbis
+    mock_render.return_value = HttpResponse("login")
 
-    # Simulate a POST request with incorrect username/password
-    request = factory.post("/login", {"username": "testuser", "password": "wrongpass"})
+    request = attach_session(
+        factory.post("/login", {"username": "testuser", "password": "wrongpass"}),
+    )
+    response = views.login(request)
 
-    _ = login(request)
-
-    mock_openbis_class.assert_called_once()
+    assert isinstance(response, HttpResponse)
+    mock_openbis_class.assert_called_once_with("https://openbis.example")
     mock_openbis.login.assert_called_once_with(
         "testuser",
         "wrongpass",
         save_token=True,
     )
-    # Check that the error message is passed to the template
     assert mock_render.called
-    call_args = mock_render.call_args
-    assert "error" in call_args[0][2]
-    assert (
-        call_args[0][2]["error"]
-        == "Invalid username/password or personal access token."
-    )
+    context = mock_render.call_args[0][2]
+    assert context["error"] == "Invalid username/password or personal access token."
     assert mock_openbis.logged_in is False
 
 
+@override_settings(OPENBIS_URL="https://openbis.example")
 @patch("openbis_upload_helper.app.views.render")
 @patch("openbis_upload_helper.app.views.Openbis")
-def test_set_token_failure(mock_openbis_class, mock_render, mock_openbis):
-    mock_render.return_value = None
-
+def test_set_token_failure(
+    mock_openbis_class,
+    mock_render,
+    mock_openbis,
+    attach_session,
+):
     mock_openbis_class.return_value = mock_openbis
-    # Simulate a POST request with an invalid personal access token
-    request = factory.post("/login", {"personal_access_token": "invalidtoken"})
-    _ = login(request)
+    mock_render.return_value = HttpResponse("login")
 
-    mock_openbis_class.assert_called_once()
+    request = attach_session(
+        factory.post("/login", {"personal_access_token": "invalidtoken"}),
+    )
+    response = views.login(request)
+
+    assert isinstance(response, HttpResponse)
+    mock_openbis_class.assert_called_once_with("https://openbis.example")
     mock_openbis.set_token.assert_called_once_with(
         "invalidtoken",
         save_token=True,
     )
-    # Check that the error message is passed to the template
     assert mock_render.called
-    call_args = mock_render.call_args
-    assert "error" in call_args[0][2]
-    assert (
-        call_args[0][2]["error"]
-        == "Invalid username/password or personal access token."
-    )
+    context = mock_render.call_args[0][2]
+    assert context["error"] == "Invalid username/password or personal access token."
     assert mock_openbis.logged_in is False
+
+
+@patch("openbis_upload_helper.app.views.render")
+def test_login_view_get(mock_render, attach_session):
+    mock_render.return_value = HttpResponse("login")
+
+    request = attach_session(factory.get("/login"))
+    response = views.login(request)
+
+    assert isinstance(response, HttpResponse)
+    mock_render.assert_called_once()
+    context = mock_render.call_args[0][2]
+    assert context["error"] is None
+
+
+@patch("openbis_upload_helper.app.views.logout")
+def test_logout_view_flushes_session_and_redirects(mock_logout, attach_session):
+    request = attach_session(factory.get("/logout"))
+
+    response = views.logout_view(request)
+
+    assert request.session.flushed is True
+    mock_logout.assert_called_once_with(request)
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("login")
+
+
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_redirects_when_not_logged_in(mock_get_openbis, attach_session):
+    mock_get_openbis.return_value = None
+
+    request = attach_session(factory.get("/"))
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("login")
+
+
+@patch("openbis_upload_helper.app.views.reorganize_spaces")
+@patch("openbis_upload_helper.app.views.extract_name")
+@patch("openbis_upload_helper.app.views.preload_context_request")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+@patch("openbis_upload_helper.app.views.render")
+def test_homepage_get_space_select(
+    mock_render,
+    mock_get_openbis,
+    mock_preload,
+    mock_extract_name,
+    mock_reorganize,
+    mock_openbis,
+    attach_session,
+):
+    mock_openbis.get_spaces.return_value = [SimpleNamespace(code="BAM_1")]
+    mock_openbis.get_projects.return_value = [SimpleNamespace(code="P1")]
+    mock_openbis.get_experiments.return_value = [SimpleNamespace(code="C1")]
+    mock_get_openbis.return_value = mock_openbis
+    mock_preload.return_value = ({}, [])
+    mock_extract_name.side_effect = ["BAM_1", "P1", "C1"]
+    mock_reorganize.return_value = ["BAM_1"]
+    mock_render.return_value = HttpResponse("home")
+
+    request = attach_session(
+        factory.get("/?space_select=1&space=TEST"),
+    )
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponse)
+    context = mock_render.call_args[0][2]
+    assert context["selected_space"] == "TEST"
+    assert context["projects"] == ["P1"]
+    assert context["collections"] == ["C1"]
+    assert context["spaces"] == ["BAM_1"]
+
+
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_get_reset_clears_session_and_redirects(
+    mock_get_openbis,
+    mock_openbis,
+    attach_session,
+):
+    mock_get_openbis.return_value = mock_openbis
+
+    request = attach_session(factory.get("/?reset=1"))
+    request.session["uploaded_files"] = [("f.txt", "/tmp/f.txt")]
+    request.session["checker_logs"] = ["log"]
+
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    assert "uploaded_files" not in request.session
+    assert "checker_logs" not in request.session
+
+
+@patch("openbis_upload_helper.app.views.render")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_upload_no_files(
+    mock_get_openbis,
+    mock_render,
+    mock_openbis,
+    attach_session,
+):
+    mock_get_openbis.return_value = mock_openbis
+    mock_render.return_value = HttpResponse("home")
+
+    request = attach_session(
+        factory.post("/", {"upload": "1"}),
+    )
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponse)
+    context = mock_render.call_args[0][2]
+    assert context["error"] == "No files uploaded."
+
+
+@patch("openbis_upload_helper.app.views.FileLoader")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_upload_success(
+    mock_get_openbis,
+    mock_file_loader,
+    mock_openbis,
+    attach_session,
+    make_uploaded_file,
+):
+    mock_get_openbis.return_value = mock_openbis
+    loader_instance = mock_file_loader.return_value
+    loader_instance.load_files.return_value = [("f.txt", "/tmp/f.txt")]
+
+    request = attach_session(
+        factory.post(
+            "/",
+            {
+                "upload": "1",
+                "selected_space": "SPACE",
+                "project_name": "PROJ",
+                "collection_name": "COLL",
+                "selected_files": "f.txt",
+            },
+            content_type=MULTIPART_CONTENT,
+        ),
+    )
+    request.FILES.setlist("files[]", [make_uploaded_file("f.txt")])
+
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    assert request.session["selected_space"] == "SPACE"
+    assert request.session["project_name"] == "PROJ"
+    assert request.session["collection_name"] == "COLL"
+    assert request.session["uploaded_files"] == [("f.txt", "/tmp/f.txt")]
+    assert request.session["parsers_assigned"] is False
+
+
+@patch("openbis_upload_helper.app.views.render")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_assign_parsers_no_files(
+    mock_get_openbis,
+    mock_render,
+    mock_openbis,
+    attach_session,
+):
+    mock_get_openbis.return_value = mock_openbis
+    mock_render.return_value = HttpResponse("home")
+
+    request = attach_session(factory.post("/", {"assign_parsers": "1"}))
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponse)
+    context = mock_render.call_args[0][2]
+    assert context["error"] == "No files uploaded. Please upload files first."
+
+
+@patch("openbis_upload_helper.app.views.FileRemover")
+@patch("openbis_upload_helper.app.views.log_results")
+@patch("openbis_upload_helper.app.views.run_parser")
+@patch("openbis_upload_helper.app.views.FilesParser")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_assign_parsers_success(
+    mock_get_openbis,
+    mock_files_parser,
+    mock_run_parser,
+    mock_log_results,
+    mock_file_remover,
+    mock_openbis,
+    attach_session,
+):
+    mock_get_openbis.return_value = mock_openbis
+    files_parser_instance = mock_files_parser.return_value
+    files_parser_instance.assign_parsers.return_value = (
+        {"ParserA": ["file1.txt"]},
+        {object(): ["/tmp/file1.txt"]},
+    )
+    mock_log_results.return_value = [
+        {"event": "ok", "timestamp": "t", "level": "info"},
+    ]
+
+    request = attach_session(factory.post("/", {"assign_parsers": "1"}))
+    request.session["uploaded_files"] = [("file1.txt", "/tmp/file1.txt")]
+    request.session["parser_choices"] = ["ParserA"]
+    request.session["project_name"] = "PROJ"
+    request.session["collection_name"] = "COLL"
+    request.session["selected_space"] = "SPACE"
+
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    mock_run_parser.assert_called_once()
+    assert request.session["checker_logs"] == mock_log_results.return_value
+    assert request.session["parsers_assigned"] is True
+    mock_file_remover.return_value.cleanup.assert_called_once()
+
+
+@patch("openbis_upload_helper.app.views.FileRemover")
+@patch("openbis_upload_helper.app.views.FilesParser")
+@patch("openbis_upload_helper.app.views.render")
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_homepage_assign_parsers_error(
+    mock_get_openbis,
+    mock_render,
+    mock_files_parser,
+    mock_file_remover,
+    mock_openbis,
+    attach_session,
+):
+    mock_get_openbis.return_value = mock_openbis
+    mock_render.return_value = HttpResponse("home")
+    mock_files_parser.return_value.assign_parsers.side_effect = ValueError("boom")
+
+    request = attach_session(factory.post("/", {"assign_parsers": "1"}))
+    request.session["uploaded_files"] = [("file1.txt", "/tmp/file1.txt")]
+    request.session["parser_choices"] = ["ParserA"]
+
+    response = views.homepage(request)
+
+    assert isinstance(response, HttpResponse)
+    context = mock_render.call_args[0][2]
+    assert context["error"] == "boom"
+    mock_file_remover.return_value.cleanup.assert_called_once()
+
+
+@patch("openbis_upload_helper.app.views.get_openbis_from_cache")
+def test_clear_state(mock_get_openbis, mock_openbis, attach_session):
+    mock_get_openbis.return_value = mock_openbis
+    request = attach_session(factory.post("/clear"))
+    request.session["checker_logs"] = ["log"]
+
+    response = views.clear_state(request)
+
+    assert isinstance(response, HttpResponseRedirect)
+    assert response.url == reverse("homepage")
+    assert "checker_logs" not in request.session


### PR DESCRIPTION
@LucasZimm check this out. I worked on top of your branch #30 . Once you check these, we can merge into your branch, and this into the cookiecutter install.

Here is a summary:

1. Expanded `test_views.py` to cover login, logout_view, homepage, and clear_state positive/negative paths, with full mocking of OpenBIS and side effects.
2. Centralized shared test fixtures in [conftest.py](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#), including Django setup, request session helpers, and file upload helpers.
3. Made the entry point loader test deterministic by mocking importlib.metadata.entry_points instead of depending on an installed external parser.
4. Removed the placeholder [test_dummy.py](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#).
5. Restructured [pyproject.toml](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#):
    - Moved [project] metadata to the top.
    - Removed DJANGO_SETTINGS_MODULE from pytest config (moved Django setup to [conftest.py](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) instead).
    - Merged dev dependencies into [[project.optional-dependencies].dev](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) and removed the duplicated [[dependency-groups].dev](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) list. I also cleaned the ruff rules, because some of them are **extremely annoying** (I mean, maximum 5 inputs for a function, wtf???).

I pretty much used [CODEX](https://openai.com/codex/) to expand the test_views.py, with some tweeks here and there. Now, I did all of this because:

- The original view tests were good for you to learn how to Mock stuff, but they only exercised a narrow subset of login and skipped session/cache/redirect behavior, leaving most of [views.py](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) uncovered. I tried to extend this so you see what "doing tests" means (not because what you did was wrong or incomplete; I just sent you a smaller subset on purpose).
- The tests relied on implicit Django settings and URL resolution, which caused failures in isolation; a session-scoped Django setup fixture fixes this consistently. If I am not mistaken, this is an issue of the cookiecutter.
- The entry point test should not require an external package to be installed. Mocking makes it stable and CI-safe.
- [test_dummy.py](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) was redundant after real tests were added.
- [pyproject.toml](https://file+.vscode-resource.vscode-cdn.net/home/jpizarro/.vscode/extensions/openai.chatgpt-0.4.71-linux-x64/webview/#) cleanup avoids conflicting dev dependency definitions and aligns with your preference for [project] metadata at the top.